### PR TITLE
Define versao necessaria do python para maior ou igual a 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
     entry_points='''
         [console_scripts]
         laguinho=laguinho:cli
-    '''
+    ''',
+    python_requires='>=3',
 )


### PR DESCRIPTION
#### Issue Relacionada

#15

#### Qual o propósito dessa pull request?
Restringir a versão, do python, para no mínimo a 3.
Em setup.py, adicionei o seguinte argumento na função setup():
`python_requires='>=3'`

<!-- Descreva aqui o contexto e o que foi feito-->

#### Como pode ser manualmente testado?

#### Tipo de mudanças

<!--- Adicione ✔️ onde for aplicável -->
✔️ | Tipo de mudança
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | Nova feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- Mudança que faz com que funcionalidades atuais mudem. -->
_ | Refatoração <!-- Melhoria técnica, não causando mudança de funcionalidades atuais. -->
