### PR TITLE
Integra publish de dataset com laguinho-api

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 click = "*"
+requests = "*"
 
 [requires]
 python_version = "3"

--- a/laguinho/commands/publish.py
+++ b/laguinho/commands/publish.py
@@ -1,13 +1,18 @@
 import click
 import json
 import os
+import requests
+
+API_URL = "http://localhost:8080"
+
+API_ENDPOINT = API_URL + "/datasets"
 
 @click.command('publish', short_help='Publica dataset no laguinho.')
 def publish():
     """Publica um dataset no laguinho para que possa ser baixado por outras pessoas por meio do comando get."""
     click.echo('Iniciando publish no laguinho.')
     init_laguinho()
-    click.echo('Feature em desenvolvimento, o dataset ainda não será publicado.')
+    post_dataset()
 
 def init_laguinho():
 
@@ -21,9 +26,9 @@ def init_laguinho():
 
     metadata['name'] = click.prompt('\nNome do dataset', type=str, default=folder_name)
     metadata['url'] = click.prompt('URL do repositório do Github', type=str)
-    metadata['data_format'] = click.prompt("Formato dos arquivos", type=str, default="csv")
+    metadata['format'] = click.prompt("Formato dos arquivos", type=str, default="csv")
     
-    data_path = '/' + metadata['name'] + '.' + metadata['data_format']
+    data_path = '/' + metadata['name'] + '.' + metadata['format']
     metadata['path'] = click.prompt("Caminho dentro do repositório onde está localizado o dataset", type=str, default= data_path)
 
     maintainers = click.prompt("Mantenedores (separados por virgula)", type=str, default="", show_default=False)
@@ -42,6 +47,18 @@ def init_laguinho():
     else:
         click.echo('Operação cancelada.')
 
+def post_dataset():
+    data = read_laguinho_json()
+    response = requests.post(url=API_ENDPOINT, json=data)
+    if (response.ok):
+        click.echo('Sucesso ao publicar o dataset no laguinho!')
+    else:
+        click.echo('Falha ao publicar o dataset no laguinho')
+
+def read_laguinho_json():
+    file_path = './laguinho.json' 
+    with open(file_path, 'r') as fp:
+        return json.load(fp)
 
 def write_laguinho_json(data):
     file_path = './laguinho.json' 

--- a/laguinho/commands/publish.py
+++ b/laguinho/commands/publish.py
@@ -2,8 +2,7 @@ import click
 import json
 import os
 import requests
-
-API_URL = "http://localhost:8080"
+from ..values import API_URL
 
 API_ENDPOINT = API_URL + "/datasets"
 
@@ -20,7 +19,8 @@ def init_laguinho():
     folder_name = os.path.basename(dir_path)
 
     if os.path.exists(dir_path + "/laguinho.json"):
-        click.confirm("\nArquivo laguinho.json já existe. Deseja sobrescrever?", abort=True)
+        click.confirm("\nArquivo laguinho.json já existe. Deseja sobrescrever?")
+        return
                 
     metadata = {}
 

--- a/laguinho/values.py
+++ b/laguinho/values.py
@@ -1,14 +1,13 @@
 import os
 
 development = True
+# TODO quando o laguinho estiver hospedado, substituir essa linha
+# API_URL = 'https://laguinho.opendevufcg.org'
+API_URL = 'http://localhost:8080'
 
 if development:
-  API_URL = os.getenv('API_URL', 'http://localhost:8080')
-else:
-  # TODO quando o laguinho estiver hospedado, substituir essa linha
-  # API_URL = 'https://laguinho.opendevufcg.org'
-  API_URL = os.getenv('API_URL', 'http://localhost:8080')
+    API_URL = os.getenv('API_URL', 'http://localhost:8080')
 
 def set_development():
-  global development
-  development = True
+    global development
+    development = True

--- a/laguinho/values.py
+++ b/laguinho/values.py
@@ -1,0 +1,14 @@
+import os
+
+development = True
+
+if development:
+  API_URL = os.getenv('API_URL', 'http://localhost:8080')
+else:
+  # TODO quando o laguinho estiver hospedado, substituir essa linha
+  # API_URL = 'https://laguinho.opendevufcg.org'
+  API_URL = os.getenv('API_URL', 'http://localhost:8080')
+
+def set_development():
+  global development
+  development = True

--- a/laguinho/values.py
+++ b/laguinho/values.py
@@ -6,7 +6,7 @@ development = True
 API_URL = 'http://localhost:8080'
 
 if development:
-    API_URL = os.getenv('API_URL', 'http://localhost:8080')
+    API_URL = os.getenv('LAGUINHO_API_URL', 'http://localhost:8080')
 
 def set_development():
     global development

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 from laguinho import cli
+from laguinho.values import set_development
 
 if __name__ == "__main__":
     cli()
+    set_development()

--- a/run.py
+++ b/run.py
@@ -2,5 +2,5 @@ from laguinho import cli
 from laguinho.values import set_development
 
 if __name__ == "__main__":
-    cli()
     set_development()
+    cli()


### PR DESCRIPTION
#### Issue Relacionada
<!-- Substitua NUMERO_DA_ISSUE com sua issue -->

Resolve #21 

#### Qual o propósito dessa pull request?
Integrar publish de datasets com laguinho-api. 
Foi implementado um post passando o arquivo laguinho.json no body
<!-- Descreva aqui o contexto e o que foi feito-->

#### Como pode ser manualmente testado?
Instalar as dependências, pois foi instalado a biblioteca `requests`
`pipenv install`
Rodar o comando de publish:
`pipenv run laguinho-dev publish`
Depois, para testar o que foi publicado, basta fazer um get no postman para laguinho-api:
`http://localhost:8080/datasets`

#### Tipo de mudanças

<!--- Adicione ✔️ onde for aplicável -->
✔️ | Tipo de mudança
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | Nova feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- Mudança que faz com que funcionalidades atuais mudem. -->
_ | Refatoração <!-- Melhoria técnica, não causando mudança de funcionalidades atuais. -->
