### PR TITLE
Adição de comando para configurar o token

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ $ pipenv install
 $ pipenv run laguinho-dev [COMANDO]
 ```
 
+### Gerando um Github Token
+
+![github_token](https://user-images.githubusercontent.com/33502846/67691356-33fda580-f97d-11e9-82c2-315ea2dd7358.gif)
+
+#### Passo a passo
+
+Para baixar os dados pelo comando `get`, é necessário fornecer um token de autenticação do Github, para gerá-lo basta seguir os passos descritos abaixo ou acesse este [link](https://github.com/settings/tokens/new) e pule para o passo 5:
+
+1. Primeiramente, acesse a sua [página de configurações do Github](https://github.com/settings/profile)
+2. Selecione a aba `Developer Settings`
+3. Vá em `Personal Access Token`
+4. Clique em `Generate new Token`
+5. Adicione um nome e selecione a caixa de escolha `user`
+6. Clique em `Generate token`
+7. Copie o token gerado (obs: tenha certeza de ter copiado, uma vez que ele não será disponilizado novamente, apenas ao criar um novo token) e cole na CLI quando requisitado ou executando o comando `configure`.
+
 ## Como Contribuir
 
 Quer implementar alguma nova funcionalidade ou corrigir algum bug? Pode ir dando uma olhada nas issues abertas pra saber no que estamos trabalhando ou se preferir pode abrir sua própria caso queira corrigir ou adicionar algo novo! 

--- a/laguinho/__init__.py
+++ b/laguinho/__init__.py
@@ -1,6 +1,7 @@
 import click
 from .commands.get import get
 from .commands.publish import publish
+from .commands.configure import configure
 
 @click.group()
 def cli():
@@ -9,3 +10,4 @@ def cli():
 
 cli.add_command(get)
 cli.add_command(publish)
+cli.add_command(configure)

--- a/laguinho/commands/configure.py
+++ b/laguinho/commands/configure.py
@@ -9,6 +9,10 @@ def configure(token):
     config_path = os.path.expanduser('~') + '/laguinho.config'
     file_content = {'GITHUB_TOKEN':token}
 
+    if os.path.exists(config_path):
+        click.confirm("\nJá existe um token configurado. Deseja sobrescrever?")
+        return
+
     with open(config_path, 'w')  as file:
         json.dump(file_content, file, indent=2)
 

--- a/laguinho/commands/configure.py
+++ b/laguinho/commands/configure.py
@@ -1,0 +1,15 @@
+import os
+import json
+import click
+
+@click.command('configure', short_help="Configura o token de autenticação do Github.")
+@click.argument('token', required=True, type=str)
+def configure(token):
+    """Configura o token de autenticação da API do Github"""
+    config_path = os.path.expanduser('~') + '/laguinho.config'
+    file_content = {'GITHUB_TOKEN':token}
+
+    with open(config_path, 'w')  as file:
+        json.dump(file_content, file, indent=2)
+
+    click.echo('Token atualizado!')

--- a/laguinho/commands/get.py
+++ b/laguinho/commands/get.py
@@ -8,7 +8,7 @@ from ..utils.github_api import create_github_url, request_github_api
 @click.argument('name', required=True, type=str)
 def get(name):
     """Retorna os dados disponiveis de um determinado repositório do github."""
-    click.echo('Recuperando dados de %s' % name)
+    click.echo('\nRecuperando dados de %s' % name)
     metadata = {"url": "https://github.com/opendevufcg/laguinho", "path": "/laguinho", "name": "dados"}
     try:
         download_dataset(metadata)

--- a/laguinho/utils/__init__.py
+++ b/laguinho/utils/__init__.py
@@ -18,7 +18,7 @@ def load_token():
             token = json.load(file)['GITHUB_TOKEN']
 
     else:
-        click.echo('Para baixar os dados do github, é necessário possuir um TOKEN de permissão do Github, caso você não saiba como gerar, siga as instruções desse link.')
+        click.echo('Para baixar os dados do github, é necessário possuir um TOKEN de permissão do Github, caso você não saiba como gerar, siga as instruções descritas no README.')
         token = click.prompt("Por favor, insira um TOKEN do Github válido").strip()
         file_content = {'GITHUB_TOKEN': token}
         with open(config_path, 'w')  as file:

--- a/laguinho/utils/__init__.py
+++ b/laguinho/utils/__init__.py
@@ -1,0 +1,29 @@
+"""É carregado o token do github na variável de ambiente"""
+import os
+import json
+import click
+
+def load_token():
+    """Carrega o token do github
+    A função verifica se existe o arquivo
+    laguinho.config na raiz do usuário, caso
+    exista, ele lê o token e retorna, caso não
+    exista, é criado e requsitado ao usuário que
+    informe um token do github
+    """
+    config_path = os.path.expanduser('~') + '/laguinho.config'
+
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as file:
+            token = json.load(file)['GITHUB_TOKEN']
+
+    else:
+        click.echo('Para baixar os dados do github, é necessário possuir um TOKEN de permissão do Github, caso você não saiba como gerar, siga as instruções desse link.')
+        token = click.prompt("Por favor, insira um TOKEN do Github válido").strip()
+        file_content = {'GITHUB_TOKEN': token}
+        with open(config_path, 'w')  as file:
+            json.dump(file_content, file, indent=2)
+
+    return token
+
+os.environ['GITHUB_TOKEN'] = load_token()

--- a/laguinho/utils/github_api.py
+++ b/laguinho/utils/github_api.py
@@ -1,3 +1,4 @@
+import os
 import requests
 
 def create_github_url(metadata, is_file=False):
@@ -23,11 +24,14 @@ def create_github_url(metadata, is_file=False):
 def request_github_api(url):
     """Faz uma requisição a API do Github.
 
-
-    Faz uma requisição a API do Github.
+    A função faz uma requisição a API do
+    github, para isso ela lê a variável de ambiente
+    que possui o oauth token do github e passa
+    como parametro no headers da requisição.
 
     Args:
             url: URL do Github a ser requisitada.
     """
-    response = requests.get(url)
+    token = os.environ.get('GITHUB_TOKEN', '')
+    response = requests.get(url, headers={"Authorization":  "token " + token})
     return response.content


### PR DESCRIPTION
#### Issue Relacionada
Issue #27 

#### Qual o propósito dessa pull request?

Adicionar o código referente a autenticação do usuário a partir do oauth token do github. O usuário também pode atualizar o token cadastrado a partir do novo comando `configure`. Também foi adicionado ao readme um passo a passo de como gerar o token.

#### Como pode ser manualmente testado?

Executando o comando `get` ou o `configure`, ao executar, deve ser requitado que o usuário forneca um token de autenticação.  

#### Tipo de mudanças

✔️ | Tipo de mudança
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | Nova feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- Mudança que faz com que funcionalidades atuais mudem. -->
_ | Refatoração <!-- Melhoria técnica, não causando mudança de funcionalidades atuais. -->

